### PR TITLE
Change default configuration to empty include array

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface GraftreeConfig {
 
 const DEFAULT_CONFIG: GraftreeConfig = {
   mode: "copy",
-  include: [".env"]
+  include: []
 };
 
 export async function loadConfig(): Promise<GraftreeConfig> {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -28,7 +28,7 @@ describe("Config", () => {
     
     expect(config).toEqual({
       mode: "copy",
-      include: [".env"]
+      include: []
     });
   });
 
@@ -95,7 +95,7 @@ describe("Config", () => {
     // Should fall back to default config
     expect(config).toEqual({
       mode: "copy",
-      include: [".env"]
+      include: []
     });
   });
 });


### PR DESCRIPTION
## Summary
- Remove `.env` from default include patterns
- Update tests to match new default behavior
- Make git-graftree behave identically to git worktree when no configuration is provided

## Test plan
- [x] All existing tests pass
- [x] Config tests updated to verify empty default array
- [x] Integration tests confirm no regression

🤖 Generated with [Claude Code](https://claude.ai/code)