### PR TITLE
Fix EEXIST error when creating duplicate symlinks

### DIFF
--- a/src/file-operations.ts
+++ b/src/file-operations.ts
@@ -15,6 +15,12 @@ export async function copyOrLinkFile(options: FileOperationOptions): Promise<voi
     console.warn(`Warning: Source file ${sourcePath} does not exist, skipping`);
     return;
   }
+
+  // Skip if target already exists
+  if (existsSync(targetPath)) {
+    console.log(`Target already exists, skipping: ${targetPath}`);
+    return;
+  }
   
   // Ensure target directory exists
   const targetDir = path.dirname(targetPath);


### PR DESCRIPTION
## Summary
- Fixed EEXIST error that occurred when creating duplicate symlinks for the same file
- Added existence check for target files before creating symlinks/copies
- This prevents errors when the same file path is processed multiple times during glob pattern expansion

## Test plan
- [x] All existing tests pass
- [x] Manual testing confirms the fix resolves the EEXIST error
- [x] CLI build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)