### PR TITLE
docs: fix default include value in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Create `.graftreerc` in your project root or home directory:
 ```
 
 - **mode**: `"copy"` or `"symlink"` (default: `"copy"`)
-- **include**: Files/patterns to copy (default: `[".env"]`)
+- **include**: Files/patterns to copy (default: `[]`)
 - **exclude**: Patterns to exclude (optional)
 
 Local `.graftreerc` overrides global `~/.graftreerc`.


### PR DESCRIPTION
## Summary
- Fix incorrect default value documentation for `include` configuration in README.md
- Update `[".env"]` to `[]` to match actual implementation in src/config.ts

## Background
Recent commit (4c9c8ce) changed default config to empty include array, but README wasn't updated to reflect this change.

## Changes
- README.md line 57: Updated default include value from `[".env"]` to `[]`

🤖 Generated with [Claude Code](https://claude.ai/code)