### PR TITLE
feat: Replace lcov-reporter-action with bun-coverage-report-action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: 70-10/bun-coverage-report-action@v1.0.1
         with:
           lcov-path: ./coverage/lcov.info
-          min-coverage: 90
+          min-coverage: 65
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TypeScript type check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Bun Coverage Report
         if: github.event_name == 'pull_request'
-        uses: 70-10/bun-coverage-report-action@v1
+        uses: 70-10/bun-coverage-report-action@v1.0.1
         with:
           lcov-path: ./coverage/lcov.info
           min-coverage: 90

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,10 +41,10 @@ jobs:
 
       - name: Bun Coverage Report
         if: github.event_name == 'pull_request'
-        uses: 70-10/bun-coverage-report-action@v1.0.1
+        uses: 70-10/bun-coverage-report-action@v1.0.2
         with:
           lcov-path: ./coverage/lcov.info
-          min-coverage: 65
+          min-coverage: 90
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run TypeScript type check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,13 @@ jobs:
       - name: Run tests with coverage
         run: bun test --coverage
 
-      - name: LCOV Coverage Report
+      - name: Bun Coverage Report
         if: github.event_name == 'pull_request'
-        uses: romeovs/lcov-reporter-action@v0.4.0
+        uses: 70-10/bun-coverage-report-action@v1
         with:
-          lcov-file: ./coverage/lcov.info
+          lcov-path: ./coverage/lcov.info
+          min-coverage: 90
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          filter-changed-files: false
 
       - name: Run TypeScript type check
         run: bunx tsc --noEmit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-graftree",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create git worktree and copy/symlink files from base directory",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Replace `romeovs/lcov-reporter-action` with `70-10/bun-coverage-report-action@v1` for better Bun integration
- Set minimum coverage threshold to 90% (matching bunfig.toml configuration)
- Update parameter names and remove unnecessary options

## Benefits
- Better integration with Bun test coverage system
- Consistent coverage reporting from the same author (70-10)
- Simplified configuration with appropriate defaults

## Test plan
- [x] Verify tests pass with coverage generation
- [x] Confirm LCOV file is generated correctly
- [x] Check workflow syntax is valid
- [ ] Test PR coverage reporting functionality (will be verified when this PR is created)

🤖 Generated with [Claude Code](https://claude.ai/code)